### PR TITLE
CICDL-258: Test NPM Trusted Publishers (OIDC) auth

### DIFF
--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -8,8 +8,9 @@ on:
 jobs:
   publish:
     if: ${{ github.event.label.name == 'npm-ready-for-publish' }}
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{ github.event.pull_request.head.ref }}
       supported_versions: '[18]'
+      use_trusted_publisher: true
     secrets: inherit


### PR DESCRIPTION
## Summary

Test PR to validate NPM Trusted Publishers (OIDC) authentication in the publish workflow.

- Points publish workflow at `CICDL-258-use-trusted-providers` branch of `github-actions-workflows` (not `master` yet — that PR is pending)
- Sets `use_trusted_publisher: true` to exercise the OIDC path

## What this tests

- Whether `id-token: write` permission is correctly inherited through the reusable workflow chain
- Whether npm CLI detects the OIDC environment and uses it for auth
- Which workflow filename to register on npmjs.com (`job_workflow_ref` vs `workflow_ref`)

## Before triggering publish

- [ ] Register a Trusted Publisher on npmjs.com for `test-public-npm-module` (owner: `pipedrive`, repo: `test-public-npm-module`, workflow filename: TBD — try `reusable_cicd-npm-package-publish.yml` first)
- [ ] Label this PR with `npm-ready-for-publish` to trigger the publish workflow
- [ ] Check the workflow run logs to confirm OIDC auth is used

> **Do NOT merge** — test only. Revert to `@master` + remove `use_trusted_publisher` once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)