### PR TITLE
CICDL-258: Test NPM Trusted Publishers (OIDC) end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ This repository is used to test the reusable_cicd-npm-publish workflow for publi
 
 
 ## Validate granular token
+
+## Validate NPM Trusted Publishers (OIDC)


### PR DESCRIPTION
## Summary

Test PR to validate the full NPM Trusted Publishers (OIDC) flow with the `id-token: write` permission fix in place.

- Publish workflow on master already has `use_trusted_publisher: true` pointing at `CICDL-258-use-trusted-providers`
- The `id-token: write` permission is now correctly propagated through the reusable workflow chain

## How to trigger

Add the `npm-ready-for-publish` label to this PR.

## What to verify

- [ ] Workflow run shows npm authenticating via OIDC (no `NPM_TOKEN` used)
- [ ] Package publishes successfully to npmjs.com
- [ ] No `ENEEDAUTH` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)