### PR TITLE
CICDL-258: Test OIDC with id-token permission on consumer job

### DIFF
--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     if: ${{ github.event.label.name == 'npm-ready-for-publish' }}
+    permissions:
+      id-token: write
+      contents: read
     uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -9,8 +9,9 @@ jobs:
   publish:
     if: ${{ github.event.label.name == 'npm-ready-for-publish' }}
     permissions:
-      id-token: write
-      contents: read
+      id-token: write   # OIDC npm publish
+      contents: write   # repos.merge() in package-checks
+      actions: write    # functional test dispatch (drop if skip_functional_tests: true)
     uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary

Third test iteration for NPM Trusted Publishers (OIDC).

- Adds `permissions: id-token: write` to the consumer `publish` job — this is required at every level of the reusable workflow chain; setting it only in the reusable workflow is not sufficient
- Still pointing at `CICDL-258-use-trusted-providers` branch

## How to trigger

Add the `npm-ready-for-publish` label.

## Expected outcome

GITHUB_TOKEN Permissions in the run log should now show `id-token: write`, and npm should authenticate via OIDC without `ENEEDAUTH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)