### PR TITLE
CICDL-378: Remove use_trusted_publisher and pin to @master

### DIFF
--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write   # OIDC npm publish
       contents: write   # repos.merge() in package-checks
       actions: write    # functional test dispatch (drop if skip_functional_tests: true)
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@CICDL-378-remove-npm-public-publish-token
     with:
       revision: ${{ github.event.pull_request.head.ref }}
       supported_versions: '[22]'

--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -12,9 +12,8 @@ jobs:
       id-token: write   # OIDC npm publish
       contents: write   # repos.merge() in package-checks
       actions: write    # functional test dispatch (drop if skip_functional_tests: true)
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@CICDL-258-use-trusted-providers
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@master
     with:
       revision: ${{ github.event.pull_request.head.ref }}
       supported_versions: '[22]'
-      use_trusted_publisher: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- Removes the now-unnecessary `use_trusted_publisher: true` input from the npm publish workflow call
- Switches workflow ref from `@CICDL-258-use-trusted-providers` to `@master`

OIDC Trusted Publishers is the only publish path after [pipedrive-actions/github-actions-workflows#4](https://github.com/pipedrive-actions/github-actions-workflows/pull/4) removed the token-based code path.

**⚠️ Merge after** [pipedrive-actions/github-actions-workflows#4](https://github.com/pipedrive-actions/github-actions-workflows/pull/4) is merged.

## Test plan

- [ ] No functional change — OIDC publish continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)